### PR TITLE
Use the newer version of ELK 7.9.3 with nodejs 10.22.1-alpine

### DIFF
--- a/7.9/Dockerfile
+++ b/7.9/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:10.22.0-alpine
+FROM node:10.22.1-alpine
 
 LABEL maintainer "https://github.com/blacktop"
 
 RUN apk add --no-cache openjdk8-jre tini su-exec
 
-ENV STACK 7.9.1
+ENV STACK 7.9.3
 
 RUN apk add --no-cache libzmq bash nodejs nginx apache2-utils openssl nss
 RUN mkdir -p /usr/local/lib \


### PR DESCRIPTION
use the newer version of ELK 7.9.3 with nodejs 10.22.1-alpine